### PR TITLE
CQDG-684 apply vqsr or hard filtering depending on sequencing type

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1,12 +1,155 @@
-
-
 nextflow.enable.dsl = 2
+
+include { VQSR } from "./subworkflows/vqsr"
+include { hardFiltering } from './modules/hardFilter'
+include { splitMultiAllelics        } from './modules/vep'
+include { vep                       } from './modules/vep'
+include { tabix                     } from './modules/vep'
+
+enum SequencingType {
+    WGS,
+    WES
+}
+
+enum SampleFileFormat {
+    V1,
+    V2
+}
+
+/**
+Parse the sample file (tsv) and returns the 2 following channels as a map:
+    - meta : (familyId, metadata_dictionary)
+    - files : (familyId, [single.patient.file.gvcf.gz, single.patient.file.gvcf.gz.tbi])
+
+Note: one line per patient is emitted for the meta channel, i.e. it contains duplicates.
+
+The metadata dictionary contains the following keys:
+- size: number of patients in the family
+- sequencingType: type of sequencing data, can be either 'WGS' or 'WES'
+
+## Input Format ##
+
+You can specify the input format via configuration parameter `sampleFileFormat`. 
+We support 2 different formats: `V1` and `V2`. The default is `V1`.
+
+Columns in V1 format:
+```
+familyId    filePatient1    filePatient2    ...
+```
+
+Columns in V2 format:
+```
+familyId    SequencingType  filePatient1 filePatient2   ...
+```
+
+In the V1 format, the sequencing type is assumed to be the same for all samples and is specified through
+the configuration parameter `sequencingType` (default to `WGS`).
+
+## Potiential improvements ##
+
+Consider the following improvements:
+- Rethink propagation of metadata in the workflow: https://training.nextflow.io/advanced/metadata/
+- Add validation step
+*/
+def sampleChannel() {    
+    def rowMapper = getRowMapper() 
+
+    return Channel.fromPath(file("$params.sampleFile"))
+        .splitCsv(sep: '\t', strip: true)
+        .map(rowMapper)
+        .flatMap { it ->
+            return it.files.collect{f -> [familyId: it.familyId, sequencingType: it.sequencingType, size: it.files.size(), file: f]};             
+        }.multiMap { it ->
+            meta: tuple(it.familyId, [size: it.size, sequencingType: it.sequencingType])
+            files: tuple(it.familyId, file("${it.file}*"))
+        }
+}
+
+def getSampleFileFormat() {
+    if (!params.sampleFileFormat) {
+        log.warn("Using default value `V1` for parameter `sampleFileFormat`")
+        params.sampleFileFormat="V1"
+    }
+    return findParamInEnum("sampleFileFormat", params.sampleFileFormat.toUpperCase(), SampleFileFormat)
+}
+
+def getSequencingType() {
+    if (!params.sequencingType) {
+        log.warn("Using default value `WGS` for parameter `sequencingType`")
+        params.sequencingType="WGS"
+    }
+    return findParamInEnum("sequencingType", params.sequencingType.toUpperCase(), SequencingType)
+}
+
+def findParamInEnum(paramName, paramValue, enumInstance) {
+    def validValues = enumInstance.values()*.name()
+    if (!validValues.contains(paramValue)) {
+        def validValuesStr = validValues.collect{"`$it`"}.join(", ")
+        error("Invalid value for parameter `$paramName`: `$paramValue`. Possible values are: $validValuesStr")
+    }
+    return enumInstance.valueOf(paramValue)
+}
+
+/**
+Get row mapper that match the configured sample file format
+
+Note: it is returned as a closure to guaranty the compatibility with nextflow channel operators
+*/
+def getRowMapper() {
+    def format = getSampleFileFormat()
+
+    if (format == SampleFileFormat.V1) {
+        def sequencingType = getSequencingType()
+        return {columns -> rowMapperV1(columns, sequencingType)}
+    }
+    return {columns -> rowMapperV2(columns)}
+}
+
+/** 
+Transform a row from the sample file in V1 format from a list structure to a map structure.
+*/
+def rowMapperV1(columns, sequencingType) {
+    return [
+        familyId: columns[0],
+        sequencingType: sequencingType,
+        files: columns.tail()
+    ]
+}
+
+/** 
+Transform a row from the sample file in V2 format from a list structure to a map structure
+*/
+def rowMapperV2(columns) {
+    return [
+        familyId: columns[0],
+        sequencingType: columns[1].toUpperCase() as SequencingType,
+        files: columns[2..-1]
+    ]
+}
+
+/**
+Tag variants that are probable artifacts
+
+In the case of whole genome sequencing data, we use the vqsr procedure.
+For whole exome sequencing data, since the vqsr procedure is not supported, we use
+a hard filtering approach.
+*/
+def tagArtifacts(inputChannel, metadataChannel, hardFilters) {
+    def inputSequencingTypes = inputChannel.join(metadataChannel)
+    
+    def wgs = inputSequencingTypes.filter{it[2].sequencingType == SequencingType.WGS}.map(it -> it.dropRight(1))
+    def wes = inputSequencingTypes.filter{it[2].sequencingType == SequencingType.WES}.map(it -> it.dropRight(1))
+
+    def wgs_filtered = VQSR(wgs)
+    def wes_filtered = hardFiltering(wes, hardFilters)
+
+    return wgs_filtered.concat(wes_filtered)
+}
 
 /**
 Exclude MNPs detected with bedtools
 */
-
-process excludeMNPs{
+process excludeMNPs {
     label 'medium'
     
     input:
@@ -28,7 +171,9 @@ process excludeMNPs{
     """
 }
 
-
+/**
+Combine per-sample gVCF files into a multi-sample gVCF file 
+*/
 process importGVCF {
 
     label 'medium'
@@ -49,13 +194,11 @@ process importGVCF {
     gatk -version
     gatk --java-options "-Xmx8g"  CombineGVCFs -R $referenceGenome/${params.referenceGenomeFasta} $exactGvcfFiles -O ${familyId}.combined.gvcf.gz -L $broadResource/${params.intervalsFile}
     """       
-
 }    
 
 /**
 Keep only SNP and Indel 
 */
-
 process genotypeGVCF {
     label 'geno'
 
@@ -75,67 +218,41 @@ process genotypeGVCF {
     """
 }
 
-
-
-
-/**
-Parse a tsv and return multiple chanels with 
-    - sizes : size by family id
-    - files : files by family id
-*/
-def sampleChannel() {
-   Channel.fromPath(file("$params.sampleFile"))
-               .splitCsv(sep: '\t')
-               .flatMap { it ->
-                    files = it.tail().findAll{ c -> c?.trim() };
-                    return files.collect{ f -> [familyId: it.first(), size: files.size(), file: f ]}; 
-                }.multiMap { it ->
-                    sizes: tuple(it.familyId, it.size)
-                    files: tuple(it.familyId, file("${it.file}*"))
-                }                
-}
-
-include { variantRecalibratorSNP    } from './modules/vqsr'
-include { variantRecalibratorIndel  } from './modules/vqsr'
-include { applyVQSRSNP              } from './modules/vqsr'
-include { applyVQSRIndel            } from './modules/vqsr'
-include { splitMultiAllelics        } from './modules/vep'
-include { vep                       } from './modules/vep'
-include { tabix                     } from './modules/vep'
-
-
 workflow {
     referenceGenome = file(params.referenceGenome)
     broad = file(params.broad)
     vepCache = file(params.vepCache)
     file(params.outputDir).mkdirs()
 
-    sampleChannel().set{ familiesSizeFile }
+    sampleChannel().set{ sampleFile }
 
-    filtered = excludeMNPs(familiesSizeFile.files)
-                    .join(familiesSizeFile.sizes)
-                    .map{familyId, files, size -> tuple( groupKey(familyId, size), files)}
+    //Exclude MNPs and recombine files per family id
+    //(familyId, [filtered.patientUUID1.gvcf.gz, filtered.patientUUID1.gcvf.gz.tbi, filtered.patientUUID2.gcvf.gz, filtered.patientUUID2.gvcf.gz.tbi... ])
+    filtered = excludeMNPs(sampleFile.files)
+                    .join(sampleFile.meta)
+                    .map{familyId, files, meta -> tuple( groupKey(familyId, meta.size), files)}
                     .groupTuple()
                     .map{ familyId, files -> tuple(familyId, files.flatten())}
-
-    
+     
+    //Using 2 as threshold because we have 2 files per patient (gcvf.gz, gvcf.gz.tbi)
     filtered_one = filtered.filter{it[1].size() == 2}
     filtered_mult = filtered.filter{it[1].size() > 2}
 
+    //Combine per-sample gVCF files into a multi-sample gVCF file
     DB = importGVCF(filtered_mult, referenceGenome,broad)
                     .concat(filtered_one)
 
+
+    //Perform joint genotyping on one or more samples
     vcf = genotypeGVCF(DB, referenceGenome)
-                        
-    v = variantRecalibratorSNP(vcf, referenceGenome, broad).join(vcf)
-    asnp = applyVQSRSNP(v) 
 
-    indel = variantRecalibratorIndel(vcf, referenceGenome, broad).join(asnp)
-    aindel = applyVQSRIndel(indel)
+    //tag variants that are probable artifacts
+    vcfWithTags = tagArtifacts(vcf, sampleFile.meta, params.hardFilters)
 
-    s = splitMultiAllelics(aindel, referenceGenome) 
+    //tag frequent mutations in the population
+    s = splitMultiAllelics(vcfWithTags, referenceGenome) 
 
-    vep(s, referenceGenome, vepCache) 
+    //Annotating mutations
+    vep(s, referenceGenome, vepCache)
     tabix(vep.out) 
-
 }

--- a/modules/hardFilter.nf
+++ b/modules/hardFilter.nf
@@ -1,0 +1,22 @@
+process hardFiltering {
+    label 'medium'
+
+    input:
+    tuple val(prefixId), path(vcf)
+    val(filters)
+
+    output:
+    tuple val(prefixId), path("*.hardfilter.vcf.gz*")
+
+    script:
+    def exactVcfFile = vcf.find { it.name.endsWith("vcf.gz") }
+    def filterOptions = filters.collect{ "-filter \"${it.expression}\" --filter-name \"${it.name}\"" }.join(" ")
+    """
+    set -e
+
+    gatk VariantFiltration \
+     -V ${exactVcfFile} \
+    ${filterOptions} \
+     -O  ${prefixId}.hardfilter.vcf.gz
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -7,5 +7,13 @@ params {
     referenceGenomeFasta = 'Homo_sapiens_assembly38.fasta'
     vepCpu = 2
     intervalsFile = 'name_interval_file.list'
-    TSfilter = '99.0'
+    TSfilterSNP = '99.0'
+    TSfilterINDEL = '99.0'
+    hardFilters = [[name: 'QD2', expression: 'QD < 2.0'],
+                   [name: 'QUAL30', expression: 'QUAL < 30.0'],
+                   [name: 'SOR3', expression: 'SOR > 3.0'],
+                   [name: 'FS60', expression: 'FS > 60.0'],
+                   [name: 'MQ40', expression: 'MQ < 40.0'],
+                   [name: 'MQRankSum-12.5', expression: 'MQRankSum < -12.5'],
+                   [name: 'ReadPosRankSum-8', expression: 'ReadPosRankSum < -8.0']]
 }

--- a/subworkflows/vqsr/main.nf
+++ b/subworkflows/vqsr/main.nf
@@ -1,0 +1,30 @@
+include { variantRecalibratorIndel; variantRecalibratorSNP; applyVQSRIndel; applyVQSRSNP} from '../../modules/vqsr'
+
+/**
+Filter out probable artifacts from the callset using the Variant Quality Score Recalibration (VQSR) procedure
+
+The input and output formats are the same:
+    Input: (prefixId,  [some.file.vcf.gz, some.file.vcf.gz.tbi])
+
+All output files will be prefixed with the given prefixId.
+*/
+workflow VQSR {
+    take:
+        input // channel: (val(prefixId),  [.vcf.gz, .vcf.gz.tbi])
+
+    main:
+        referenceGenome = file(params.referenceGenome)
+        broad = file(params.broad)
+        
+
+        outputSNP = variantRecalibratorSNP(input, referenceGenome, broad)
+            | join(input)
+            | applyVQSRSNP 
+
+        output = variantRecalibratorIndel(input, referenceGenome, broad)
+            | join(outputSNP)
+            | applyVQSRIndel
+  
+    emit:
+        output // channel: (val(prefixId),  [.vcf.gz, .vcf.gz.tbi])
+}

--- a/subworkflows/vqsr/nextflow.config
+++ b/subworkflows/vqsr/nextflow.config
@@ -1,0 +1,24 @@
+
+// Your configuration file is expected to contain the following parameters:
+params {
+    broad = '/path/to/broad/'
+    referenceGenome = '/path/to/reference/genome/'
+    referenceGenomeFasta = 'Homo_sapiens_assembly38.fasta'
+    TSfilterSNP = '99.0'
+    TSfilterIndel = '99.0'
+}
+
+
+// All invoked processes by this workflow use the gatk command line tool. 
+// Here is an example process scope configuration.
+process {
+    withName: 'variantRecalibratorSNP|variantRecalibratorIndel|applyVQSRIndel|applyVQSRSNP' {
+        container = 'broadinstitute/gatk:4.5.0.0'
+        errorStrategy = 'retry'
+        maxRetries = 2
+        cpus = 2
+        memory = 14.GB
+        disk = {30.GB * task.attempt}
+        time = {10.h * task.attempt}
+    }
+}


### PR DESCRIPTION
The goal of this PR is to introduce logic to adapt filtering logic (vqsr vs hard filtering) depending on the sequencing data type (whole exome sequencing or whole genome sequencing).

It is assumed that the sequencing type is passed as an extra column in the sample file. We use the code `WES` for whole exome sequencing and `WGS` for whole genome sequencing. 

For compatibility, we support both this new format and the previous sample file format.  One can specify the desired format through configuration parameter "sampleFileFormat".  Use value `V1` for the previous format and `V2` for the new format.  By default, we assume the previous format, i.e. `V1`. 

If using the previous format (`V1`), by default, it will be assume that the data is whole genome sequencing data (`WGS`).  One can change this by setting the configuration parameter `sequencingType`. Use `WES` for whole exome sequencing or `WGS` for whole genome sequencing.

Note that the sequencingType option will be ignored when using the sample file format `V2`.


**Examples usage**

To use the new sample file format :
`nextlfow run main.nf -c nextflow.config [other options]  --sampleFileFormat=V2`

To use the previous sample file format and whole genome sequencing, run the nextflow command normally without specifying any extra option.

To use the previous sample file format and whole exome sequencing data:
`nextlfow run main.nf -c nextflow.config [other options]  --sequencingType=WES`

**Test procedures**

Used tiny datasets to test the following scenarios:

- successfully process whole genome sequencing data with sample file format `V2`
- successfully process whole genome sequencing data with sample file format `V1`
- successfully process whole exome sequencing data with sample file format `V2`
- successfully process whole exome sequencing data with sample file format `V1`

- make sure that, by default, sample file format is set to `V1` and sequencing type to `WGS`

- job configured for sample file format `V1`, but we pass a sample file with format `V2`: job fail early, within the first process
- job configured for sample file format `V2`, but we pass a sample file with format `V1`: job fail early, before the first process

- invalid sample file format:  job is cancelled with an informative message
- invalid sequencing type format: (when using format `V1` only): job is cancelled with an informative message

**Extra minor changes**

This PR also contains the following minor changes:
    - use only dedicated params TSfilterINDEL and TSfilterSNP in vqsr processes
    - add comments
    - minor cosmetic changes (ex: spacing)

