### PR TITLE
Add reports to outDir/pipeline_info

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -17,3 +17,21 @@ params {
                    [name: 'MQRankSum-12.5', expression: 'MQRankSum < -12.5'],
                    [name: 'ReadPosRankSum-8', expression: 'ReadPosRankSum < -8.0']]
 }
+
+def trace_timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
+timeline {
+    enabled = true
+    file    = "${params.outputDir}/pipeline_info/execution_timeline_${trace_timestamp}.html"
+}
+report {
+    enabled = true
+    file    = "${params.outputDir}/pipeline_info/execution_report_${trace_timestamp}.html"
+}
+trace {
+    enabled = true
+    file    = "${params.outputDir}/pipeline_info/execution_trace_${trace_timestamp}.txt"
+}
+dag {
+    enabled = true
+    file    = "${params.outputDir}/pipeline_info/pipeline_dag_${trace_timestamp}.html"
+}


### PR DESCRIPTION
Inspired from nf-core workflows, publishes 3 types of report to the pipeline_info directory:

1. Timestamp trace : execution_timeline_(Timestamp).html
2. Execution trace : execution_trace_(Timestamp).txt
3. Execution report : execution_report_(Timestamp).html

as well as the diagram of executed processes: pipeline_dag_(Timestamp).html