### PR TITLE
Fix and augment installed packages in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,16 @@
 FROM nextflow/nextflow:23.10.1
 
 # Adding a few command line utilities
-RUN yum update -y && yum install -y nano-2.9.8-2.amzn2.0.1.x86_64 \
-tar-2-1.26-35.amzn2.0.3.x86_64 \
-less.x86-458-9.amzn2.0.3.x86_64
+RUN yum update -y && yum install -y --setopt=skip_missing_names_on_install=False \
+nano-2.9.8-2.amzn2.0.1.x86_64 \
+tar-2:1.26-35.amzn2.0.3.x86_64 \
+less-458-9.amzn2.0.4.x86_64 \
+wget-1.14-18.amzn2.1.x86_64 \
+unzip-6.0-57.amzn2.0.1.x86_64 \
+zip-3.0-11.amzn2.0.2.x86_64 \
+rclone-1.55.1-1.amzn2.0.1.x86_64
+
+# Installing the aws cli. Using version >= 2.13.0 so that environment variable AWS_ENDPOINT_URL is supported
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.13.0.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install


### PR DESCRIPTION
  We modify the yum install command in dockerfile:
      - fix typos in package versions
      - add option to fail the command if a package cannot be found in yum install command
      - include extra packages: unzip, zip, wget, rclone
      
 We also install the aws client.
 
 I double checked that we can configure the aws client and rclone client entirely from environment variables. I will inject these environment variables in the k8s repo when configuring the nextflow pod.