### PR TITLE
Adds "stub" block to all processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ The broad directory must contain the following files:
 Finally, the vep cache directory must be specified with **vepCache**, which is usually created by vep itself on first installation.
 Generally, we only need the human files obtainable from https://ftp.ensembl.org/pub/release-112/variation/vep/homo_sapiens_vep_112_GRCh38.tar.gz
 
+### Stub run
+The -stub-run option can be added to run the "stub" block of processes instead of the "script" block. This can be helpful for testing.
 
 🚧
 

--- a/main.nf
+++ b/main.nf
@@ -178,6 +178,16 @@ process excludeMNPs {
     bcftools filter -e 'strlen(REF)>1 & strlen(REF)==strlen(ALT) & TYPE="snp"' ${exactGvcfFile} | bcftools norm -d any -O z -o ${familyId}.${uuid}.filtered.vcf.gz
     bcftools index -t ${familyId}.${uuid}.filtered.vcf.gz
     """
+    stub:
+
+    def exactGvcfFile = gvcfFile.find { it.name.endsWith("vcf.gz") }
+    def uuid = UUID.randomUUID().toString()
+    """
+    echo ${exactGvcfFile} > file
+    touch ${familyId}.${uuid}.filtered.vcf.gz
+    touch ${familyId}.${uuid}.filtered.vcf.gz.tbi
+    """
+
 }
 
 /**
@@ -203,6 +213,14 @@ process importGVCF {
     gatk -version
     gatk --java-options "-Xmx8g"  CombineGVCFs -R $referenceGenome/${params.referenceGenomeFasta} $exactGvcfFiles -O ${familyId}.combined.gvcf.gz -L $broadResource/${params.intervalsFile}
     """       
+
+    stub:
+    def exactGvcfFiles = gvcfFiles.findAll { it.name.endsWith("vcf.gz") }.collect { "-V $it" }.join(' ')
+
+    """
+    touch ${familyId}.combined.gvcf.gz
+    """       
+
 }    
 
 /**
@@ -225,6 +243,12 @@ process genotypeGVCF {
     gatk -version
     gatk --java-options "-Xmx8g" GenotypeGVCFs -R $referenceGenome/${params.referenceGenomeFasta} -V $exactGvcfFile -O ${familyId}.genotyped.vcf.gz
     """
+
+    stub:
+    def exactGvcfFile = gvcfFile.find { it.name.endsWith("vcf.gz") }
+    """
+    touch ${familyId}.genotyped.vcf.gz
+    """
 }
 
 workflow {
@@ -242,7 +266,6 @@ workflow {
                     .map{familyId, files, meta -> tuple( groupKey(familyId, meta.size), files)}
                     .groupTuple()
                     .map{ familyId, files -> tuple(familyId, files.flatten())}
-     
     //Using 2 as threshold because we have 2 files per patient (gcvf.gz, gvcf.gz.tbi)
     filtered_one = filtered.filter{it[1].size() == 2}
     filtered_mult = filtered.filter{it[1].size() > 2}

--- a/main.nf
+++ b/main.nf
@@ -183,7 +183,6 @@ process excludeMNPs {
     def exactGvcfFile = gvcfFile.find { it.name.endsWith("vcf.gz") }
     def uuid = UUID.randomUUID().toString()
     """
-    echo ${exactGvcfFile} > file
     touch ${familyId}.${uuid}.filtered.vcf.gz
     touch ${familyId}.${uuid}.filtered.vcf.gz.tbi
     """

--- a/modules/hardFilter.nf
+++ b/modules/hardFilter.nf
@@ -19,4 +19,8 @@ process hardFiltering {
     ${filterOptions} \
      -O  ${prefixId}.hardfilter.vcf.gz
     """
+    stub:
+    """
+    touch ${prefixId}.hardfilter.vcf.gz
+    """
 }

--- a/modules/vep.nf
+++ b/modules/vep.nf
@@ -19,6 +19,11 @@ process splitMultiAllelics{
     bcftools view --min-ac 1 --output-type z --output ${familyId}.splitted.vcf.gz ${familyId}.normed.vcf.gz
     bcftools index -t ${familyId}.splitted.vcf.gz
     """
+    stub
+    """
+    touch ${familyId}.splitted.vcf.gz
+    touch ${familyId}.splitted.vcf.gz.tbi
+    """
 }
 
 process vep {
@@ -59,6 +64,11 @@ process vep {
     --fields "Allele,Consequence,IMPACT,SYMBOL,Feature_type,Gene,PICK,Feature,EXON,BIOTYPE,INTRON,HGVSc,HGVSp,STRAND,CDS_position,cDNA_position,Protein_position,Amino_acids,Codons,VARIANT_CLASS,HGVSg,CANONICAL,RefSeq" \
     --no_stats
     """
+
+    stub:
+    """
+    touch variants.${familyId}.vep.vcf.gz
+    """
 }
 
 process tabix {
@@ -75,6 +85,10 @@ process tabix {
     script:
     """
     tabix $vcfFile
+    """
+    script:
+    """
+    touch ${vcfFile}.tbi
     """
 
 } 

--- a/modules/vqsr.nf
+++ b/modules/vqsr.nf
@@ -39,6 +39,12 @@ process variantRecalibratorSNP {
     --max-gaussians 6 \
     -mode SNP -O ${prefix}.recal --tranches-file ${prefix}.tranches
     """
+
+    stub:
+    """
+    touch ${prefix}.recal
+    touch ${prefix}.tranches
+    """
 }
 
 /**
@@ -77,6 +83,12 @@ process variantRecalibratorIndel {
     --max-gaussians 4 \
     -mode INDEL -O ${prefix}.recal --tranches-file ${prefix}.tranches
     """
+
+    stub:
+    """
+    touch ${prefix}.recal
+    touch ${prefix}.tranches
+    """
 }
 
 /*
@@ -106,6 +118,10 @@ process applyVQSRSNP {
     --truth-sensitivity-filter-level ${params.TSfilterSNP} \
     --create-output-variant-index true \
     -O ${prefix}.snp.vqsr_${params.TSfilterSNP}.vcf.gz
+    """
+    stub:
+    """
+    touch ${prefix}.snp.vqsr_${params.TSfilterSNP}.vcf.gz
     """
 
 }
@@ -138,5 +154,9 @@ process applyVQSRIndel {
     --truth-sensitivity-filter-level ${params.TSfilterINDEL} \
     --create-output-variant-index true \
     -O ${prefix}.snpindel.vqsr_${params.TSfilterINDEL}.vcf.gz
+    """
+    stub:
+    """
+    touch ${prefix}.snpindel.vqsr_${params.TSfilterINDEL}.vcf.gz
     """
 }


### PR DESCRIPTION
Following the "script" block in each process, the "stub" block was added. When running the pipeline with the -stub-run option, the stub blocks will be used INSTEAD of the script block. 

The stub block will create empty files satisfying the "output" specification of the process.

Additional processes added in the future will also need a "stub" block, else the -stub-run will run the "script" by default.
