### PR TITLE
Change memory allocation param for java gatk

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -205,13 +205,28 @@ process importGVCF {
     tuple val(familyId), path("*combined.gvcf.gz*")
 
     script:
+    def args = task.ext.args ?: ''
     def exactGvcfFiles = gvcfFiles.findAll { it.name.endsWith("vcf.gz") }.collect { "-V $it" }.join(' ')
+
+    def avail_mem = 3072
+    if (!task.memory) {
+        log.info '[GATK CombineGVCFs] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.'
+    } else {
+        avail_mem = (task.memory.mega*0.8).intValue()
+    }
 
     """
     echo $familyId > file
     gatk -version
-    gatk --java-options "-Xmx8g"  CombineGVCFs -R $referenceGenome/${params.referenceGenomeFasta} $exactGvcfFiles -O ${familyId}.combined.gvcf.gz -L $broadResource/${params.intervalsFile}
-    """       
+    gatk --java-options "-Xmx${avail_mem}M -XX:-UsePerfData" \\
+        CombineGVCFs \\
+        -R $referenceGenome/${params.referenceGenomeFasta} \\
+        $exactGvcfFiles \\
+        -O ${familyId}.combined.gvcf.gz \\
+        -L $broadResource/${params.intervalsFile} \\
+        $args
+    """ 
+
 
     stub:
     def exactGvcfFiles = gvcfFiles.findAll { it.name.endsWith("vcf.gz") }.collect { "-V $it" }.join(' ')
@@ -236,12 +251,26 @@ process genotypeGVCF {
     tuple val(familyId), path("*genotyped.vcf.gz*")
 
     script:
+    def args = task.ext.args ?: ''
     def exactGvcfFile = gvcfFile.find { it.name.endsWith("vcf.gz") }
+
+    def avail_mem = 3072
+    if (!task.memory) {
+        log.info '[GATK GenotypeGVCFs] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.'
+    } else {
+        avail_mem = (task.memory.mega*0.8).intValue()
+    }
     """
     echo $familyId > file
     gatk -version
-    gatk --java-options "-Xmx8g" GenotypeGVCFs -R $referenceGenome/${params.referenceGenomeFasta} -V $exactGvcfFile -O ${familyId}.genotyped.vcf.gz
+    gatk --java-options "-Xmx${avail_mem}M -XX:-UsePerfData" \\
+        GenotypeGVCFs \\
+        -R $referenceGenome/${params.referenceGenomeFasta} \\
+        -V $exactGvcfFile \\
+        -O ${familyId}.genotyped.vcf.gz \\
+        $args
     """
+
 
     stub:
     def exactGvcfFile = gvcfFile.find { it.name.endsWith("vcf.gz") }

--- a/main.nf
+++ b/main.nf
@@ -206,7 +206,6 @@ process importGVCF {
 
     script:
     def args = task.ext.args ?: ''
-    def args = task.ext.args ?: ''
     def exactGvcfFiles = gvcfFiles.findAll { it.name.endsWith("vcf.gz") }.collect { "-V $it" }.join(' ')
 
     def avail_mem = 3072
@@ -216,12 +215,6 @@ process importGVCF {
         avail_mem = (task.memory.mega*0.8).intValue()
     }
 
-    def avail_mem = 3072
-    if (!task.memory) {
-        log.info '[GATK CombineGVCFs] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.'
-    } else {
-        avail_mem = (task.memory.mega*0.8).intValue()
-    }
 
     """
     echo $familyId > file

--- a/modules/hardFilter.nf
+++ b/modules/hardFilter.nf
@@ -9,15 +9,25 @@ process hardFiltering {
     tuple val(prefixId), path("*.hardfilter.vcf.gz*")
 
     script:
+    def args = task.ext.args ?: ''
     def exactVcfFile = vcf.find { it.name.endsWith("vcf.gz") }
     def filterOptions = filters.collect{ "-filter \"${it.expression}\" --filter-name \"${it.name}\"" }.join(" ")
+
+    def avail_mem = 3072
+    if (!task.memory) {
+        log.info '[GATK VariantFiltration] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.'
+    } else {
+        avail_mem = (task.memory.mega*0.8).intValue()
+    }
     """
     set -e
 
-    gatk VariantFiltration \
-     -V ${exactVcfFile} \
-    ${filterOptions} \
-     -O  ${prefixId}.hardfilter.vcf.gz
+    gatk --java-options "-Xmx${avail_mem}M -XX:-UsePerfData" \\
+        VariantFiltration \\
+        -V ${exactVcfFile} \\
+        ${filterOptions} \\
+        -O  ${prefixId}.hardfilter.vcf.gz \\
+        $args
     """
     stub:
     """

--- a/modules/hardFilter.nf
+++ b/modules/hardFilter.nf
@@ -10,7 +10,6 @@ process hardFiltering {
 
     script:
     def args = task.ext.args ?: ''
-    def args = task.ext.args ?: ''
     def exactVcfFile = vcf.find { it.name.endsWith("vcf.gz") }
     def filterOptions = filters.collect{ "-filter \"${it.expression}\" --filter-name \"${it.name}\"" }.join(" ")
 
@@ -21,12 +20,6 @@ process hardFiltering {
         avail_mem = (task.memory.mega*0.8).intValue()
     }
 
-    def avail_mem = 3072
-    if (!task.memory) {
-        log.info '[GATK VariantFiltration] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.'
-    } else {
-        avail_mem = (task.memory.mega*0.8).intValue()
-    }
     """
     set -e
 

--- a/modules/vep.nf
+++ b/modules/vep.nf
@@ -41,7 +41,6 @@ process vep {
 
     script:
     def args = task.ext.args ?: ''
-    def args = task.ext.args ?: ''
     def exactVcfFile = vcfFile.find { it.name.endsWith("vcf.gz") }
     """
     vep \\

--- a/modules/vep.nf
+++ b/modules/vep.nf
@@ -40,29 +40,31 @@ process vep {
     tuple val(familyId), path("*vep.vcf.gz")
 
     script:
+    def args = task.ext.args ?: ''
     def exactVcfFile = vcfFile.find { it.name.endsWith("vcf.gz") }
     """
-    vep \
-    --fork ${params.vepCpu} \
-    --dir ${vepCache} \
-    --offline \
-    --cache \
-    --fasta $referenceGenome/${params.referenceGenomeFasta} \
-    --input_file $exactVcfFile \
-    --format vcf \
-    --vcf \
-    --output_file variants.${familyId}.vep.vcf.gz \
-    --compress_output bgzip \
-    --xref_refseq \
-    --variant_class \
-    --numbers \
-    --hgvs \
-    --hgvsg \
-    --canonical \
-    --symbol \
-    --flag_pick \
-    --fields "Allele,Consequence,IMPACT,SYMBOL,Feature_type,Gene,PICK,Feature,EXON,BIOTYPE,INTRON,HGVSc,HGVSp,STRAND,CDS_position,cDNA_position,Protein_position,Amino_acids,Codons,VARIANT_CLASS,HGVSg,CANONICAL,RefSeq" \
-    --no_stats
+    vep \\
+        --fork ${params.vepCpu} \\
+        --dir ${vepCache} \\
+        --offline \\
+        --cache \\
+        --fasta $referenceGenome/${params.referenceGenomeFasta} \\
+        --input_file $exactVcfFile \\
+        --format vcf \\
+        --vcf \\
+        --output_file variants.${familyId}.vep.vcf.gz \\
+        --compress_output bgzip \\
+        --xref_refseq \\
+        --variant_class \\
+        --numbers \\
+        --hgvs \\
+        --hgvsg \\
+        --canonical \\
+        --symbol \\
+        --flag_pick \\
+        --fields "Allele,Consequence,IMPACT,SYMBOL,Feature_type,Gene,PICK,Feature,EXON,BIOTYPE,INTRON,HGVSc,HGVSp,STRAND,CDS_position,cDNA_position,Protein_position,Amino_acids,Codons,VARIANT_CLASS,HGVSg,CANONICAL,RefSeq" \\
+        --no_stats \\
+        $args
     """
 
     stub:
@@ -83,8 +85,12 @@ process tabix {
     path "*.tbi"
 
     script:
+    def args = task.ext.args ?: ''
+
     """
-    tabix $vcfFile
+    tabix \\
+        $vcfFile \\
+        $args
     """
     script:
     """

--- a/modules/vqsr.nf
+++ b/modules/vqsr.nf
@@ -18,18 +18,9 @@ process variantRecalibratorSNP {
     
     script:
     def args = task.ext.args ?: ''
-    def args = task.ext.args ?: ''
     def exactVcfFile = vcf.find { it.name.endsWith("vcf.gz") }
     def tranches = ["100.0", "99.95", "99.9", "99.8", "99.6", "99.5", "99.4", "99.3", "99.0"].collect{"-tranche $it"}.join(' ')
     def annotationValues = ["QD","MQRankSum","ReadPosRankSum","FS","MQ","SOR","DP"].collect{"-an $it"}.join(' ')
-
-    def avail_mem = 3072
-    if (!task.memory) {
-        log.info '[GATK VariantRecalibrator] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.'
-    } else {
-        avail_mem = (task.memory.mega*0.8).intValue()
-    }
-
 
     def avail_mem = 3072
     if (!task.memory) {
@@ -96,13 +87,6 @@ process variantRecalibratorIndel {
     } else {
         avail_mem = (task.memory.mega*0.8).intValue()
     }
-
-    def avail_mem = 3072
-    if (!task.memory) {
-        log.info '[GATK VariantRecalibrator] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.'
-    } else {
-        avail_mem = (task.memory.mega*0.8).intValue()
-    }
     """
     set -e
     echo $prefix > file
@@ -145,16 +129,8 @@ process applyVQSRSNP {
 
     script:
     def args = task.ext.args ?: ''
-    def args = task.ext.args ?: ''
     def exactVcfFile = vcf.find { it.name.endsWith("vcf.gz") }
     def exactRecal = recal.find { it.name.endsWith("recal") }
-
-    def avail_mem = 3072
-    if (!task.memory) {
-        log.info '[GATK ApplyVQSR] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.'
-    } else {
-        avail_mem = (task.memory.mega*0.8).intValue()
-    }
 
     def avail_mem = 3072
     if (!task.memory) {
@@ -211,13 +187,19 @@ process applyVQSRIndel {
     """
     set -e
     echo $prefix > file
-    gatk --java-options "-Xms4G -Xmx4G -XX:ParallelGCThreads=2" ApplyVQSR \
-    -V ${exactVcfFile} \
-    --recal-file ${exactRecal} \
-    -mode INDEL \
-    --tranches-file ${tranches} \
-    --truth-sensitivity-filter-level ${params.TSfilterINDEL} \
-    --create-output-variant-index true \
-    -O ${prefix}.snpindel.vqsr_${params.TSfilterINDEL}.vcf.gz
+    gatk --java-options "-Xmx${avail_mem}M -XX:-UsePerfData" \\
+        ApplyVQSR \\
+        -V ${exactVcfFile} \\
+        --recal-file ${exactRecal} \\
+        -mode INDEL \\
+        --tranches-file ${tranches} \\
+        --truth-sensitivity-filter-level ${params.TSfilterINDEL} \\
+        --create-output-variant-index true \\
+        -O ${prefix}.snpindel.vqsr_${params.TSfilterINDEL}.vcf.gz \\
+        $args
+    """
+    stub:
+    """
+    touch ${prefix}.snpindel.vqsr_${params.TSfilterINDEL}.vcf.gz
     """
 }

--- a/modules/vqsr.nf
+++ b/modules/vqsr.nf
@@ -17,27 +17,38 @@ process variantRecalibratorSNP {
     tuple val(prefix), path("*.recal*"), path("*.tranches")
     
     script:
+    def args = task.ext.args ?: ''
     def exactVcfFile = vcf.find { it.name.endsWith("vcf.gz") }
     def tranches = ["100.0", "99.95", "99.9", "99.8", "99.6", "99.5", "99.4", "99.3", "99.0"].collect{"-tranche $it"}.join(' ')
     def annotationValues = ["QD","MQRankSum","ReadPosRankSum","FS","MQ","SOR","DP"].collect{"-an $it"}.join(' ')
+
+    def avail_mem = 3072
+    if (!task.memory) {
+        log.info '[GATK VariantRecalibrator] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.'
+    } else {
+        avail_mem = (task.memory.mega*0.8).intValue()
+    }
+
     """
     set -e
     echo $prefix > file
-    gatk --java-options "-Xms4G -Xmx4G -XX:ParallelGCThreads=2" VariantRecalibrator \
-    $tranches \
-    --trust-all-polymorphic \
-    -R $referenceGenome/${params.referenceGenomeFasta} \
-    -V ${exactVcfFile} \
-    --resource:hapmap,known=false,training=true,truth=true,prior=15 \
-    ${broadResource}/hapmap_3.3.hg38.vcf.gz  \
-    --resource:omni,known=false,training=true,truth=false,prior=12 \
-    ${broadResource}/1000G_omni2.5.hg38.vcf.gz \
-    --resource:1000G,known=false,training=true,truth=false,prior=10 \
-    ${broadResource}/1000G_phase1.snps.high_confidence.hg38.vcf.gz \
-    --resource:dbsnp,known=true,training=false,truth=false,prior=7 ${broadResource}/Homo_sapiens_assembly38.dbsnp138.vcf \
-    $annotationValues \
-    --max-gaussians 6 \
-    -mode SNP -O ${prefix}.recal --tranches-file ${prefix}.tranches
+    gatk --java-options "-Xmx${avail_mem}M -XX:-UsePerfData" \\
+        VariantRecalibrator \\
+        $tranches \\ 
+        --trust-all-polymorphic \\
+        -R $referenceGenome/${params.referenceGenomeFasta} \\
+        -V ${exactVcfFile} \\
+        --resource:hapmap,known=false,training=true,truth=true,prior=15 \\
+        ${broadResource}/hapmap_3.3.hg38.vcf.gz  \\
+        --resource:omni,known=false,training=true,truth=false,prior=12 \\
+        ${broadResource}/1000G_omni2.5.hg38.vcf.gz \\
+        --resource:1000G,known=false,training=true,truth=false,prior=10 \\
+        ${broadResource}/1000G_phase1.snps.high_confidence.hg38.vcf.gz \\
+        --resource:dbsnp,known=true,training=false,truth=false,prior=7 ${broadResource}/Homo_sapiens_assembly38.dbsnp138.vcf \\
+        $annotationValues \\
+        --max-gaussians 6 \\
+        -mode SNP -O ${prefix}.recal --tranches-file ${prefix}.tranches \\
+        $args
     """
 
     stub:
@@ -65,23 +76,35 @@ process variantRecalibratorIndel {
     tuple val(prefix), path("*.recal*"), path("*.tranches")
     
     script:
+    def args = task.ext.args ?: ''
     def exactVcfFile = vcf.find { it.name.endsWith("vcf.gz") }
     def tranches = ["100.0","99.95","99.9","99.5","99.0","97.0","96.0","95.0","94.0"].collect{"-tranche $it"}.join(' ')
     def annotationValues = ["FS","ReadPosRankSum","MQRankSum","QD","SOR","DP"].collect{"-an $it"}.join(' ')
+
+    def avail_mem = 3072
+    if (!task.memory) {
+        log.info '[GATK VariantRecalibrator] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.'
+    } else {
+        avail_mem = (task.memory.mega*0.8).intValue()
+    }
     """
     set -e
     echo $prefix > file
-    gatk --java-options "-Xms4G -Xmx4G -XX:ParallelGCThreads=2" VariantRecalibrator \
-    $tranches \
-    -R $referenceGenome/${params.referenceGenomeFasta} \
-    -V ${exactVcfFile} \
-    --trust-all-polymorphic \
-    --resource:mills,known=false,training=true,truth=true,prior=12 ${broadResource}/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz \
-    --resource:axiomPoly,known=false,training=true,truth=false,prior=10 ${broadResource}/Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz \
-    --resource:dbsnp,known=true,training=false,truth=false,prior=2 ${broadResource}/Homo_sapiens_assembly38.dbsnp138.vcf \
-    $annotationValues \
-    --max-gaussians 4 \
-    -mode INDEL -O ${prefix}.recal --tranches-file ${prefix}.tranches
+    gatk --java-options "-Xmx${avail_mem}M -XX:-UsePerfData" \\
+        VariantRecalibrator \\
+        $tranches \\
+        -R $referenceGenome/${params.referenceGenomeFasta} \\
+        -V ${exactVcfFile} \\
+        --trust-all-polymorphic \\
+        --resource:mills,known=false,training=true,truth=true,prior=12 ${broadResource}/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz \\
+        --resource:axiomPoly,known=false,training=true,truth=false,prior=10 ${broadResource}/Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz \\
+        --resource:dbsnp,known=true,training=false,truth=false,prior=2 ${broadResource}/Homo_sapiens_assembly38.dbsnp138.vcf \\
+        $annotationValues \\
+        --max-gaussians 4 \\
+        -mode INDEL \\
+        -O ${prefix}.recal \\
+        --tranches-file ${prefix}.tranches \\
+        $args
     """
 
     stub:
@@ -105,19 +128,29 @@ process applyVQSRSNP {
     tuple val(prefix), path("*.snp.vqsr_${params.TSfilterSNP}.vcf.gz*")
 
     script:
+    def args = task.ext.args ?: ''
     def exactVcfFile = vcf.find { it.name.endsWith("vcf.gz") }
     def exactRecal = recal.find { it.name.endsWith("recal") }
+
+    def avail_mem = 3072
+    if (!task.memory) {
+        log.info '[GATK ApplyVQSR] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.'
+    } else {
+        avail_mem = (task.memory.mega*0.8).intValue()
+    }
     """
     set -e
     echo $prefix > file
-    gatk --java-options "-Xms4G -Xmx4G -XX:ParallelGCThreads=2" ApplyVQSR \
-    -V ${exactVcfFile} \
-    --recal-file ${exactRecal} \
-    -mode SNP \
-    --tranches-file ${tranches} \
-    --truth-sensitivity-filter-level ${params.TSfilterSNP} \
-    --create-output-variant-index true \
-    -O ${prefix}.snp.vqsr_${params.TSfilterSNP}.vcf.gz
+    gatk --java-options "-Xmx${avail_mem}M -XX:-UsePerfData" \\
+        ApplyVQSR \\
+        -V ${exactVcfFile} \\
+        --recal-file ${exactRecal} \\
+        -mode SNP \\
+        --tranches-file ${tranches} \\
+        --truth-sensitivity-filter-level ${params.TSfilterSNP} \\
+        --create-output-variant-index true \\
+        -O ${prefix}.snp.vqsr_${params.TSfilterSNP}.vcf.gz \\
+        $args
     """
     stub:
     """
@@ -141,19 +174,29 @@ process applyVQSRIndel {
     tuple val(prefix), path("*.snpindel.vqsr_${params.TSfilterINDEL}.vcf.gz*")
 
     script:
+    def args = task.ext.args ?: ''
     def exactVcfFile = vcf.find { it.name.endsWith("vcf.gz") }
     def exactRecal = recal.find { it.name.endsWith("recal") }
+
+    def avail_mem = 3072
+    if (!task.memory) {
+        log.info '[GATK ApplyVQSR] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.'
+    } else {
+        avail_mem = (task.memory.mega*0.8).intValue()
+    }
     """
     set -e
     echo $prefix > file
-    gatk --java-options "-Xms4G -Xmx4G -XX:ParallelGCThreads=2" ApplyVQSR \
-    -V ${exactVcfFile} \
-    --recal-file ${exactRecal} \
-    -mode INDEL \
-    --tranches-file ${tranches} \
-    --truth-sensitivity-filter-level ${params.TSfilterINDEL} \
-    --create-output-variant-index true \
-    -O ${prefix}.snpindel.vqsr_${params.TSfilterINDEL}.vcf.gz
+    gatk --java-options "-Xmx${avail_mem}M -XX:-UsePerfData" \\
+        ApplyVQSR \\
+        -V ${exactVcfFile} \\
+        --recal-file ${exactRecal} \\
+        -mode INDEL \\
+        --tranches-file ${tranches} \\
+        --truth-sensitivity-filter-level ${params.TSfilterINDEL} \\
+        --create-output-variant-index true \\
+        -O ${prefix}.snpindel.vqsr_${params.TSfilterINDEL}.vcf.gz \\
+        $args
     """
     stub:
     """


### PR DESCRIPTION
Change memory dedicated ressources for java option in GATK command to be compliant with the config file.

Also add argument at the end of each command. This allow to add extra param using `ext.args`  in the config file. 

Good practice from nf-core.