### PR TITLE
Add Nf-core module MultiQC

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -1,0 +1,1 @@
+repository_type: pipeline

--- a/modules.json
+++ b/modules.json
@@ -1,0 +1,17 @@
+{
+  "name": "",
+  "homePage": "",
+  "repos": {
+    "https://github.com/nf-core/modules.git": {
+      "modules": {
+        "nf-core": {
+          "multiqc": {
+            "branch": "master",
+            "git_sha": "8f2062e7b4185590fb9f43c275381a31a6544fc0",
+            "installed_by": ["modules"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/nf-core/multiqc/environment.yml
+++ b/modules/nf-core/multiqc/environment.yml
@@ -1,0 +1,7 @@
+name: multiqc
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::multiqc=1.22.2

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -1,0 +1,55 @@
+process MULTIQC {
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/multiqc:1.22.2--pyhdfd78af_0' :
+        'biocontainers/multiqc:1.22.2--pyhdfd78af_0' }"
+
+    input:
+    path  multiqc_files, stageAs: "?/*"
+    path(multiqc_config)
+    path(extra_multiqc_config)
+    path(multiqc_logo)
+
+    output:
+    path "*multiqc_report.html", emit: report
+    path "*_data"              , emit: data
+    path "*_plots"             , optional:true, emit: plots
+    path "versions.yml"        , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def config = multiqc_config ? "--config $multiqc_config" : ''
+    def extra_config = extra_multiqc_config ? "--config $extra_multiqc_config" : ''
+    def logo = multiqc_logo ? /--cl-config 'custom_logo: "${multiqc_logo}"'/ : ''
+    """
+    multiqc \\
+        --force \\
+        $args \\
+        $config \\
+        $extra_config \\
+        $logo \\
+        .
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        multiqc: \$( multiqc --version | sed -e "s/multiqc, version //g" )
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    mkdir multiqc_data
+    touch multiqc_plots
+    touch multiqc_report.html
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        multiqc: \$( multiqc --version | sed -e "s/multiqc, version //g" )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/multiqc/meta.yml
+++ b/modules/nf-core/multiqc/meta.yml
@@ -1,0 +1,58 @@
+name: multiqc
+description: Aggregate results from bioinformatics analyses across many samples into a single report
+keywords:
+  - QC
+  - bioinformatics tools
+  - Beautiful stand-alone HTML report
+tools:
+  - multiqc:
+      description: |
+        MultiQC searches a given directory for analysis logs and compiles a HTML report.
+        It's a general use tool, perfect for summarising the output from numerous bioinformatics tools.
+      homepage: https://multiqc.info/
+      documentation: https://multiqc.info/docs/
+      licence: ["GPL-3.0-or-later"]
+input:
+  - multiqc_files:
+      type: file
+      description: |
+        List of reports / files recognised by MultiQC, for example the html and zip output of FastQC
+  - multiqc_config:
+      type: file
+      description: Optional config yml for MultiQC
+      pattern: "*.{yml,yaml}"
+  - extra_multiqc_config:
+      type: file
+      description: Second optional config yml for MultiQC. Will override common sections in multiqc_config.
+      pattern: "*.{yml,yaml}"
+  - multiqc_logo:
+      type: file
+      description: Optional logo file for MultiQC
+      pattern: "*.{png}"
+output:
+  - report:
+      type: file
+      description: MultiQC report file
+      pattern: "multiqc_report.html"
+  - data:
+      type: directory
+      description: MultiQC data dir
+      pattern: "multiqc_data"
+  - plots:
+      type: file
+      description: Plots created by MultiQC
+      pattern: "*_data"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@abhi18av"
+  - "@bunop"
+  - "@drpatelh"
+  - "@jfy133"
+maintainers:
+  - "@abhi18av"
+  - "@bunop"
+  - "@drpatelh"
+  - "@jfy133"

--- a/modules/nf-core/multiqc/tests/main.nf.test
+++ b/modules/nf-core/multiqc/tests/main.nf.test
@@ -1,0 +1,84 @@
+nextflow_process {
+
+    name "Test Process MULTIQC"
+    script "../main.nf"
+    process "MULTIQC"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "multiqc"
+
+    test("sarscov2 single-end [fastqc]") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of(file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastqc/test_fastqc.zip', checkIfExists: true))
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.report[0] ==~ ".*/multiqc_report.html" },
+                { assert process.out.data[0] ==~ ".*/multiqc_data" },
+                { assert snapshot(process.out.versions).match("multiqc_versions_single") }
+            )
+        }
+
+    }
+
+    test("sarscov2 single-end [fastqc] [config]") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of(file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastqc/test_fastqc.zip', checkIfExists: true))
+                input[1] = Channel.of(file("https://github.com/nf-core/tools/raw/dev/nf_core/pipeline-template/assets/multiqc_config.yml", checkIfExists: true))
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.report[0] ==~ ".*/multiqc_report.html" },
+                { assert process.out.data[0] ==~ ".*/multiqc_data" },
+                { assert snapshot(process.out.versions).match("multiqc_versions_config") }
+            )
+        }
+    }
+
+    test("sarscov2 single-end [fastqc] - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of(file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastqc/test_fastqc.zip', checkIfExists: true))
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.report.collect { file(it).getName() } +
+                                process.out.data.collect { file(it).getName() } +
+                                process.out.plots.collect { file(it).getName() } +
+                                process.out.versions ).match("multiqc_stub") }
+            )
+        }
+
+    }
+}

--- a/modules/nf-core/multiqc/tests/main.nf.test.snap
+++ b/modules/nf-core/multiqc/tests/main.nf.test.snap
@@ -1,0 +1,41 @@
+{
+    "multiqc_versions_single": {
+        "content": [
+            [
+                "versions.yml:md5,ddbc971a8307f9b9b7b973714cde29d0"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-10T11:50:10.874341679"
+    },
+    "multiqc_stub": {
+        "content": [
+            [
+                "multiqc_report.html",
+                "multiqc_data",
+                "multiqc_plots",
+                "versions.yml:md5,ddbc971a8307f9b9b7b973714cde29d0"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-10T11:50:49.271943761"
+    },
+    "multiqc_versions_config": {
+        "content": [
+            [
+                "versions.yml:md5,ddbc971a8307f9b9b7b973714cde29d0"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-10T11:50:34.046706025"
+    }
+}

--- a/modules/nf-core/multiqc/tests/tags.yml
+++ b/modules/nf-core/multiqc/tests/tags.yml
@@ -1,0 +1,2 @@
+multiqc:
+  - modules/nf-core/multiqc/**


### PR DESCRIPTION
A Nf-core official module is required for Lint to run without crashing.
MultiQC was chosen because it is often used as the default option in Nf-core templates (such as with nf-core create)

The only change I did was creating the .nf-core.yml file and run 
nf-core modules install multiqc